### PR TITLE
applying constant line-height to texts in popup window

### DIFF
--- a/quick-tabs/assets/styles-popup.css
+++ b/quick-tabs/assets/styles-popup.css
@@ -31,6 +31,7 @@ body {
   max-height: 500px;
   overflow: hidden;
   overflow-y: auto;
+  line-height: 1.25;
 }
 
 .qs_input {
@@ -66,7 +67,7 @@ div.template {
 	padding-top: 1px;
 	padding-bottom: 1px;
   clear:both;
-  height: 26px;
+  height: 27px;
 }
 
 div.tabimage {


### PR DESCRIPTION
making total height of texts as desired in all fonts.
(japanese fonts in particular)

**line-height: normal** (browser's default style) gives different heights for different fonts
http://meyerweb.com/eric/thoughts/2008/05/06/line-height-abnormal/

japanese fonts (which i use and are used in many of the pages i open as title), tend to take larger space, making popup page looking very dirty.
(url texts are out of each boxes)

overcome it by applying constant line-height (instead of **normal**), giving total height of each line
27px: (12px \* 1.25 = 15px) + (9px \* 1.25 = 11.25px, then rendered in 12px)
