### PR TITLE
add key shortcut to launch extension popup

### DIFF
--- a/quick-tabs/manifest.json
+++ b/quick-tabs/manifest.json
@@ -25,5 +25,16 @@
    "options_page": "options.html",
    "permissions": [ "tabs", "http://*/", "https://*/" ],
    "update_url": "http://clients2.google.com/service/update2/crx",
-   "version": "2013.8.4"
+   "version": "2013.10.24",
+
+   "commands": {
+      "_execute_browser_action": {
+         "suggested_key": {
+           "windows": "Ctrl+M",
+           "mac": "Command+M",
+           "chromeos": "Ctrl+M",
+           "linux": "Ctrl+M"
+         }
+      }
+   }
 }


### PR DESCRIPTION
Since Chrome 25, it's possible to specify keyboard shortcuts that can perform actions that javascript can't, like opening the popup of the extension (the one you get when you click the extension icon in the top bar).

I've used this to change the default behavior when pressing Ctrl+M - now that popup will open, making the search experience much less disruptive (especially when using a tiling window manager like I am). Users can adjust the shortcut in [chrome://extensions/](chrome://extensions/) by scrolling all the way to the bottom and clicking "Keyboard shortcuts".
