### PR TITLE
PR: Improve loading performance

### DIFF
--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -178,14 +178,15 @@ $(document).ready(function() {
 
   // clear the tab table
   var template = $(".template");
-  template.empty();
 
-  drawCurrentTabs(template);
-
-  drawClosedTabs(template);
-
-  // show the tab table once it has been completed
-  template.show();
+  // the timeout seems to improve the loading time significantly
+  setTimeout(function(){
+    template.empty();
+    drawCurrentTabs(template);
+    drawClosedTabs(template);
+    // show the tab table once it has been completed
+    template.show();
+  }, 0);
 
   $('#searchbox').quicksearch('.template .tab', {
     stripeRows: ['odd', 'even'],


### PR DESCRIPTION
As it was in #50 stated, the loading time of the popup is quite slow. I currently have 90 tabs open and the popup takes approx. 5 seconds to open.
I figured out that postponing the population of the template improves this situation a lot. Now it takes approx. 250 ms and feels almost instant.
Maybe somebody can verify that this works for him, too.
