### PR TITLE
Added an option to allow a user to select different style next/prev keybindings

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -65,6 +65,14 @@ function setClosedTabsSize(val) {
   resizeClosedTabs();
 }
 
+function nextPrevStyle() {
+   return localStorage["next_prev_style"];
+}
+
+function setNextPrevStyle(val) {
+    localStorage["next_prev_style"] = val;
+}
+
 function showDevTools() {
   var s = localStorage["include_dev_tools"];
   return s ? s == 'true' : false;

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -111,6 +111,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>
+          <td>
+              <label for="next_prev_style">Next/Prev Style:</label>
+          </td>
+          <td>
+              <select id="next_prev_style">
+                <option value="ctrln">ctrl+n / ctrl+p</option>
+                <option value="ctrlj">ctrl+j / ctrl+k</option>
+              </select>
+          </td>
+      </tr>
+      <tr>
         <td>
           Close tab shortcut:<sup>*</sup>
         </td>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -58,6 +58,7 @@ $(document).ready(function() {
   $("#show_urls").attr('checked', bg.showUrls());
   $("#show_tooltips").attr('checked', bg.showTooltips());
   $("#show_favicons").attr('checked', bg.showFavicons());
+  $("#next_prev_style").val(bg.nextPrevStyle());
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
   var sk = bg.getShortcutKey();
@@ -86,8 +87,9 @@ $(document).ready(function() {
     bg.setShowTooltips($("#show_tooltips").is(':checked'));
     bg.setShowFavicons($("#show_favicons").is(':checked'));
     bg.setShowDevTools($("#show_dev_tools").is(':checked'));
+    bg.setNextPrevStyle($("#next_prev_style").val());
 
-    bg.rebindShortcutKeys();
+    // bg.rebindShortcutKeys();
 
     // Update status to let user know options were saved.
     $(".alert").text("Options saved.")

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -211,27 +211,41 @@ $(document).ready(function() {
     timer.log("Template ready");
   }, 0);
 
-  $(document).bind('keydown.up', function() {
-    focusPrev();
-    return false;
-  });
-
-  $(document).bind('keydown.ctrl_p', function() {
-    bg.swallowSpruriousOnAfter = true;
-    focusPrev();
-    return false;
-  });
-
   $(document).bind('keydown.down', function() {
     focusNext();
     return false;
   });
 
-  $(document).bind('keydown.ctrl_n', function() {
-    bg.swallowSpruriousOnAfter = true;
-    focusNext();
+  $(document).bind('keydown.up', function() {
+    focusPrev();
     return false;
   });
+
+  // Determine which next/previous style keybindings to use
+  if (bg.nextPrevStyle() === 'ctrln') {
+      $(document).bind('keydown.ctrl_n', function() {
+        bg.swallowSpruriousOnAfter = true;
+        focusNext();
+        return false;
+      });
+      $(document).bind('keydown.ctrl_p', function() {
+        bg.swallowSpruriousOnAfter = true;
+        focusPrev();
+        return false;
+      });
+  }
+  else {
+      $(document).bind('keydown.ctrl_j', function() {
+        bg.swallowSpruriousOnAfter = true;
+        focusNext();
+        return false;
+      });
+      $(document).bind('keydown.ctrl_k', function() {
+        bg.swallowSpruriousOnAfter = true;
+        focusPrev();
+        return false;
+      });
+  }
 
   $(document).bind('keydown.return', function() {
     if(!isFocusSet()) {


### PR DESCRIPTION
On OS X, ctrl+n / ctrl+p work fine, but on Windows those already have Chrome bindings. Personally, I like the ctrl+j / ctrl+k mappings which are similar to the Vim plugin CtrlP. I added a select menu in Options to choose one of the two styles. Up and Down will still always work, and I left ctrl+n / ctrl+p as the default style.

One other thing that I ran into, was that line 90 in options.js was throwing a JS error for me (even before my change). I commented it out here, but it is probably worth checking out.

Let me know if there is something you would like to see done differently.
