### PR TITLE
only "tabs" permissions are needed

### DIFF
--- a/quick-tabs/manifest.json
+++ b/quick-tabs/manifest.json
@@ -17,7 +17,7 @@
    "manifest_version": 2,
    "name": "Quick Tabs",
    "options_page": "options.html",
-   "permissions": [ "tabs", "http://*/", "https://*/" ],
+   "permissions": [ "tabs" ],
    "update_url": "http://clients2.google.com/service/update2/crx",
    "version": "2014.7.8",
 


### PR DESCRIPTION
This fixes a bug I was seeing in Chrome Canary where the extension was
getting hijacked and then disabled by Chrome.
