### PR TITLE
add option to move tab to the last tab when switching

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -149,6 +149,14 @@ function showFavicons() {
   return s ? s == 'true' : true;
 }
 
+function moveOnSwitch() {
+  return localStorage["move_on_switch"];
+}
+
+function setMoveOnSwitch(val) {
+  localStorage["move_on_switch"] = val;
+}
+
 function setShowFavicons(val) {
   localStorage["show_favicons"] = val;
 }
@@ -319,10 +327,12 @@ function recordTabsRemoved(tabIds, callback) {
 }
 
 function switchTabs(tabid, callback) {
-
   chrome.tabs.get(tabid, function(tab) {
     chrome.windows.update(tab.windowId, {focused:true}, function () {
       chrome.tabs.update(tab.id, {selected:true});
+      if (moveOnSwitch()) {
+        chrome.tabs.move(tab.id, { index: -1 });
+      }
       if(callback) {
         callback();
       }

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -129,6 +129,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </tr>
       <tr>
         <td>
+          <label for="move_on_switch">
+            Make tab last tab on switch:
+          </label>
+        </td>
+        <td>
+          <input type='checkbox' id='move_on_switch'/>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label for="pageup_pagedown_skip_size">Skip size for PageUp/PageDown:</label>
         </td>
         <td>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -64,6 +64,7 @@ $(document).ready(function() {
   $("#show_favicons").attr('checked', bg.showFavicons());
   $("#next_prev_style").val(bg.nextPrevStyle());
   $("#pageup_pagedown_skip_size").val(bg.pageupPagedownSkipSize());
+  $("#move_on_switch").val(bg.moveOnSwitch());
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
   var sk = bg.getShortcutKey();
@@ -98,6 +99,7 @@ $(document).ready(function() {
     bg.setShowDevTools($("#show_dev_tools").is(':checked'));
     bg.setNextPrevStyle($("#next_prev_style").val());
     bg.setPageupPagedownSkipSize($("#pageup_pagedown_skip_size").val());
+    bg.setMoveOnSwitch($("#move_on_switch").is(':checked'));
 
     // bg.rebindShortcutKeys();
 


### PR DESCRIPTION
After picking a tab to switch to, that tab should become the last tab (the rightmost tab in Chrome) in the window that tab is in if this option is set.

My motivation for this is that it'd be really useful to be able to use my rightmost tabs as a "staging area" of   most recently used tabs. I've been using Quick Tabs to filter through some 20+ documentation tabs I'll have open at a time, and setting Make tab last tab on switch would let me use Ctrl+Tab and Ctrl+Shift+Tab to quickly look at my last used tabs' *content*, as opposed to having to pop up Quick Tabs' switcher and read through tab *names*.