### PR TITLE
Order opened tabs by index

### DIFF
--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -357,7 +357,7 @@ function drawCurrentTabs() {
     // render only the tabs and closed tabs on initial load (hence the empty array [] for bookmarks)
     // also drop the first entry since that's the current tab =)
     renderTabs({
-      allTabs: bg.tabs.slice(1),
+      allTabs: bg.tabs.slice(1).sort(function(aTab, anotherTab) {return aTab.index - anotherTab.index}),
       closedTabs: bg.closedTabs,
       bookmarks: []
     });


### PR DESCRIPTION
Sort the opened tabs according to their visible order (the index).
#41 and #94