### PR TITLE
Adds stripTitle function for removing HTML tags and pre/post characters, and adds this as title tooltip

### DIFF
--- a/quick-tabs/popup.html
+++ b/quick-tabs/popup.html
@@ -57,7 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </div>
       <div>
         <div class="close" id="c{{id}}" title="{{closeTitle}}"></div>
-        <div class="title"{{#tips}} title="{{{templateTitle}}}"{{/tips}}>{{{templateTitle}}}</div>
+        <div class="title"{{#tips}} title="{{{templateTooltip}}}"{{/tips}}>{{{templateTitle}}}</div>
         {{#urls}}<div class="url">{{{templateUrl}}}</div>{{/urls}}
       </div>
     </div>
@@ -75,7 +75,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </div>
         <div>
           <div class="close" id="c{{id}}" title="{{closeTitle}}"></div>
-          <div class="title"{{#tips}} title="{{{templateTitle}}}"{{/tips}}>{{{templateTitle}}}</div>
+          <div class="title"{{#tips}} title="{{{templateTooltip}}}"{{/tips}}>{{{templateTitle}}}</div>
           {{#urls}}<div class="url">{{{templateUrl}}}</div>{{/urls}}
         </div>
       </div>
@@ -93,7 +93,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           <img src="/assets/bookmarks.png" width="16" height="16" border="0">
         </div>
         <div>
-          <div class="title"{{#tips}} title="{{{templateTitle}}}"{{/tips}}>{{{templateTitle}}}</div>
+          <div class="title"{{#tips}} title="{{{templateTooltip}}}"{{/tips}}>{{{templateTitle}}}</div>
           {{#urls}}<div class="url">{{{templateUrl}}}</div>{{/urls}}
         </div>
       </div>
@@ -111,7 +111,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           <img src="/assets/history.png" width="16" height="16" border="0">
         </div>
         <div>
-          <div class="title"{{#tips}} title="{{{templateTitle}}}"{{/tips}}>{{{templateTitle}}}</div>
+          <div class="title"{{#tips}} title="{{{templateTooltip}}}"{{/tips}}>{{{templateTitle}}}</div>
           {{#urls}}<div class="url">{{{templateUrl}}}</div>{{/urls}}
         </div>
       </div>

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -411,6 +411,7 @@ function renderTabs(params, delay, currentTab) {
     if (!currentTab || obj.id !== currentTab.id) {
       obj.templateTabImage = tabImage(obj);
       obj.templateTitle = encodeHTMLSource(obj.title);
+      obj.templateTooltip = stripTitle(obj.title);
       obj.templateUrl = encodeHTMLSource(obj.displayUrl || obj.url);
       result.push(obj);
     }
@@ -420,6 +421,7 @@ function renderTabs(params, delay, currentTab) {
   var closedTabs = (params.closedTabs || []).map(function(obj) {
     obj.templateTabImage = tabImage(obj);
     obj.templateTitle = encodeHTMLSource(obj.title);
+    obj.templateTooltip = stripTitle(obj.title);
     obj.templateUrl = encodeHTMLSource(obj.displayUrl || obj.url);
     obj.templateUrlPath = encodeHTMLSource(obj.url);
     return obj;
@@ -427,6 +429,7 @@ function renderTabs(params, delay, currentTab) {
 
   var bookmarks = (params.bookmarks || []).map(function(obj) {
     obj.templateTitle = encodeHTMLSource(obj.title);
+    obj.templateTooltip = stripTitle(obj.title);
     obj.templateUrlPath = encodeHTMLSource(obj.url);
     obj.templateUrl = encodeHTMLSource(obj.displayUrl);
     return obj;
@@ -434,6 +437,7 @@ function renderTabs(params, delay, currentTab) {
 
   var history = (params.history || []).map(function(obj) {
     obj.templateTitle = encodeHTMLSource(obj.title);
+    obj.templateTooltip = stripTitle(obj.title);
     obj.templateUrlPath = encodeHTMLSource(obj.url);
     obj.templateUrl = encodeHTMLSource(obj.displayUrl);
     return obj;
@@ -548,6 +552,17 @@ function encodeHTMLSource(str) {
   return str ? str.replace(matchHTML, function(m) {
     return encodeHTMLRules[m] || m;
   }) : str;
+}
+
+/**
+ *  
+ *  Strips HTML tags and pre/post marks from given text. Used to remove these from tooltip text.
+ *  
+ */
+function stripTitle(str) {
+    str = $('<div/>').html(str).text();
+    str = str.replace(/(?:\{|\})/g, '');
+    return str;
 }
 
 function tabImage(tab) {


### PR DESCRIPTION
Only possible issue I can see is that this will also strip "{" and "}" characters from titles, but this isn't possible to change without access to the title before it passes through the search function.