### PR TITLE
Updating where shortcut keys are located, since it has changed in Chrome

### DIFF
--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -322,8 +322,7 @@ body {
   <br/>
 
   <div class="footnote">
-    &#8224; - shortcut keys managed by Chrome directly can be changed by scrolling
-    all the way to the bottom of the chrome://extensions/ page and clicking "Keyboard shortcuts".
+    &#8224; - shortcut keys managed by Chrome directly can be changed at: chrome://extensions/shortcuts
   </div>
   <div class="footnote">
     * - because of limitations with the Chrome extensions api keyboard shortcuts may not work on all pages and some


### PR DESCRIPTION
Since at least Chrome Version 67.0.3396.87 (Official Build) (OS X, 64-bit), but probably earlier.