### PR TITLE
Fix pages with curly brackets in title

### DIFF
--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -570,16 +570,9 @@ function endsWith(str, end) {
 function encodeHTMLSource(str) {
   var encodeHTMLRules = {"&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;', "\v": '<b>', "\b": '</b>'},
       matchHTML = /&(?!#?\w+;)|<|>|"|'|\/|[\v]|[\b]/g;
-  var s = str ? str.replace(matchHTML, function(m) {
-    return encodeHTMLRules[m] || m;
+  return str ? str.replace(matchHTML, function(m) {
+      return encodeHTMLRules[m] || m;
   }) : str;
-
-  if (str.indexOf("comments") != -1) {
-      chrome.extension.getBackgroundPage().console.log(str);
-
-      chrome.extension.getBackgroundPage().console.log(s);
-  }
-  return s;
 }
 
 /**

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -571,7 +571,7 @@ function encodeHTMLSource(str) {
   var encodeHTMLRules = {"&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;', "\v": '<b>', "\b": '</b>'},
       matchHTML = /&(?!#?\w+;)|<|>|"|'|\/|[\v]|[\b]/g;
   return str ? str.replace(matchHTML, function(m) {
-      return encodeHTMLRules[m] || m;
+    return encodeHTMLRules[m] || m;
   }) : str;
 }
 

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -568,11 +568,18 @@ function endsWith(str, end) {
  *
  */
 function encodeHTMLSource(str) {
-  var encodeHTMLRules = {"&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;', "{": '<b>', "}": '</b>'},
-      matchHTML = /&(?!#?\w+;)|<|>|"|'|\/|{|}/g;
-  return str ? str.replace(matchHTML, function(m) {
+  var encodeHTMLRules = {"&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;', "\v": '<b>', "\b": '</b>'},
+      matchHTML = /&(?!#?\w+;)|<|>|"|'|\/|[\v]|[\b]/g;
+  var s = str ? str.replace(matchHTML, function(m) {
     return encodeHTMLRules[m] || m;
   }) : str;
+
+  if (str.indexOf("comments") != -1) {
+      chrome.extension.getBackgroundPage().console.log(str);
+
+      chrome.extension.getBackgroundPage().console.log(s);
+  }
+  return s;
 }
 
 /**
@@ -582,7 +589,7 @@ function encodeHTMLSource(str) {
  */
 function stripTitle(str) {
     str = $('<div/>').html(str).text();
-    str = str.replace(/(?:\{|\})/g, '');
+    str = str.replace(/(?:[\v]|[\b])/g, '');
     return str;
 }
 
@@ -733,7 +740,7 @@ AbstractSearch.prototype.searchHistory = function(searchStr, since) {
  * inserts '{' and '}' at start and end
  */
 AbstractSearch.prototype.highlightString = function(string, start, end) {
-  return string.substring(0, start) + '{' + string.substring(start, end + 1) + '}' + string.substring(end + 1);
+  return string.substring(0, start) + '\v' + string.substring(start, end + 1) + '\b' + string.substring(end + 1);
 };
 
 /**


### PR DESCRIPTION
Replaced { and } with \v and \b (I don't think you can actually type those). This fixed highlighting and navigation breaking on elements with curly brackets in content.