### PR TITLE
Remove highlight underline

### DIFF
--- a/quick-tabs/assets/styles-popup.css
+++ b/quick-tabs/assets/styles-popup.css
@@ -64,7 +64,6 @@ div.template {
 
 b {
   font-weight: bold;
-  text-decoration: underline;
 }
 
 .withfocus b {


### PR DESCRIPTION
I think the highlighted results look really messy with the underline. In my opinion removing the underline makes it much easier to read and get an overview of the results.