### PR TITLE
Configurable delay in recording tab switching

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -150,6 +150,16 @@ function setClosedTabsSize(val) {
   resizeClosedTabs();
 }
 
+function getSwitchDelay() {
+  var s = localStorage["switch_delay"];
+  return s ? parseInt(s, 10) || 1500 : 1500;
+}
+
+function setSwitchDelay(val) {
+  localStorage["switch_delay"] = val;
+  resizeClosedTabs();
+}
+
 function pageupPagedownSkipSize() {
   return localStorage["pageup_pagedown_skip_size"] || 5;
 }
@@ -444,7 +454,7 @@ function updateTabOrder(tabId) {
     // reset the badge color
     chrome.browserAction.setBadgeBackgroundColor(badgeColor);
 		tabOrderUpdateFunction.cancel(); // #note big bug. Function was never canceled and hence tabOrderUpdateFunction always true
-  }, tabId === skipTabOrderUpdateTimer ? 0 : 1500);
+  }, tabId === skipTabOrderUpdateTimer ? 0 : getSwitchDelay());
 
   // clear the skip var
   skipTabOrderUpdateTimer = null;

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -183,6 +183,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </td>
 			</tr>
       <tr>
+        <td>
+          <label for="switch_delay">
+            <strong>Delay</strong> in recording tab switching:
+          </label>
+        </td>
+        <td>
+          <input id="switch_delay" type="number" min="0"/>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -70,6 +70,7 @@ $(document).ready(function() {
   $("#move_on_switch").attr('checked', bg.moveOnSwitch());
   $("#restore_last_searched_str").attr('checked', bg.restoreLastSearchedStr());
 	$("#jumpTo_latestTab_onClose").attr('checked', bg.getJumpToLatestTabOnClose());
+  $("#switch_delay").val(bg.getSwitchDelay());
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
   var sk = bg.getShortcutKey();
@@ -109,6 +110,7 @@ $(document).ready(function() {
     bg.setMoveOnSwitch($("#move_on_switch").is(':checked'));
     bg.setRestoreLastSearchedStr($("#restore_last_searched_str").is(':checked'));
 		bg.setJumpToLatestTabOnClose($("#jumpTo_latestTab_onClose").is(':checked'));
+    bg.setSwitchDelay($("#switch_delay").val());
     // bg.rebindShortcutKeys();
 
     // Update status to let user know options were saved.


### PR DESCRIPTION
Adds configuration option for delay in recording tab switch order, introduced by https://github.com/babyman/quick-tabs-chrome-extension/commit/601778d27cddbc77167e1c89cad817cb2f6a90e5 
Having migrated from Firefox, which supports MRU tabs ordering natively, 1500ms delay seems unusually high, so this configuration which might help others.

Thanks for the great extension!