### PR TITLE
Fix command key combination issue in popup.

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -90,7 +90,7 @@ function ShortcutKey(properties) {
 
 ShortcutKey.prototype.pattern = function() {
   return (this.alt ? "alt_" : "")
-      + (this.meta ? "command_" : "")
+      + (this.meta ? "meta_" : "")
       + (this.ctrl ? "ctrl_" : "")
       + (this.shift ? "shift_" : "")
       + (this.key);


### PR DESCRIPTION
Command key combination can't be detected in mac now because the hotkey doesn't match jquery.hotkeys. Another concern is although jquery.hotkeys is still working it is not actively maintained anymore. 