### PR TITLE
Fix the issue that some undefined elements are added to tabs.

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -516,10 +516,9 @@ function updateTabOrder(tabId) {
     tabOrderUpdateFunction.cancel();
   }
 
-  var idx = indexOfTab(tabId);
-
   // setup a new timer
   tabOrderUpdateFunction = new DelayedFunction(function() { // @TODO instead of DelayedFunction use setTimeout(fx, time)
+    var idx = indexOfTab(tabId);
     if (idx >= 0) { // if tab exists in tabs[]
       //log('updating tab order for', tabId, 'index', idx);
       var tab = tabs[idx];


### PR DESCRIPTION
I've figured out (hopefully only) the source of undefined elements in the `tabs` array and made a patch to fix the issue.
This fixes #326.

Actually, there was one more suspect, the callback for `chrome.tabs.get` inside the listener for `chrome.tabs.onReplaced`, since the tab might have already been closed.
But I observed no errors without the modification to that part, so the part remained unchanged.