### PR TITLE
Added option to enter custom debounce delay value

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -375,6 +375,14 @@ function setSearchString(val) {
   localStorage["search_string"] = val;
 }
 
+function getDebounceDelay() {
+  return localStorage["debounce_delay"] || 200
+}
+
+function setDebounceDelay(val) {
+  localStorage["debounce_delay"] = val;
+}
+
 function getCustomCss() {
   return localStorage["custom_css"] || '';
 }

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -240,6 +240,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </tr>
       <tr>
         <td>
+          <label for="debounce_delay">
+            <strong>Search delay</strong> in ms:
+          </label>
+        </td>
+        <td>
+          <input id="debounce_delay" type="number" min="0"/>
+          (delay in milliseconds between the last keystroke and search trigger)
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label for="closed_tabs_size">
             <strong>Closed tabs</strong> list size:
           </label>

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -246,7 +246,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </td>
         <td>
           <input id="debounce_delay" type="number" min="0"/>
-          (delay in milliseconds between the last keystroke and search trigger)
+          (delay in milliseconds between the last keystroke and tab search updates)
         </td>
       </tr>
       <tr>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -73,6 +73,7 @@ $(document).ready(function() {
   $("#restore_last_searched_str").attr('checked', bg.restoreLastSearchedStr());
   $("#jumpTo_latestTab_onClose").attr('checked', bg.getJumpToLatestTabOnClose());
   $("#tab_order_update_delay").val(bg.getTabOrderUpdateDelay());
+  $("#debounce_delay").val(bg.getDebounceDelay());
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
   var sk = bg.getShortcutKey();
@@ -116,6 +117,7 @@ $(document).ready(function() {
     bg.setRestoreLastSearchedStr($("#restore_last_searched_str").is(':checked'));
     bg.setJumpToLatestTabOnClose($("#jumpTo_latestTab_onClose").is(':checked'));
     bg.setTabOrderUpdateDelay($("#tab_order_update_delay").val());
+    bg.setDebounceDelay($("#debounce_delay").val());
     // bg.rebindShortcutKeys();
     bg.updateBadgeText();
 

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -58,7 +58,7 @@ const MAX_NON_TAB_RESULTS = 50;
 /**
  * the number of milliseconds to wait before triggering the search when the user is entering a search query
  */
-const DEBOUNCE_DELAY = bg.getDebounceDelay();
+let debounceDelay = bg.getDebounceDelay();
 
 /**
  * minimum tabs required before bookmarks get searched automatically.
@@ -401,7 +401,7 @@ $(document).ready(function() {
 /**
  * curry up a debounced version of performQuery()
  */
-const debouncedSearch = bg.debounce(performQuery, DEBOUNCE_DELAY);
+const debouncedSearch = bg.debounce(performQuery, debounceDelay);
 
 /**
  * open a new tab with `searchString`, if it looks like a valid URL open that

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -58,7 +58,7 @@ const MAX_NON_TAB_RESULTS = 50;
 /**
  * the number of milliseconds to wait before triggering the search when the user is entering a search query
  */
-const DEBOUNCE_DELAY = 200;
+const DEBOUNCE_DELAY = bg.getDebounceDelay();
 
 /**
  * minimum tabs required before bookmarks get searched automatically.


### PR DESCRIPTION
Hello,

First of all, awesome extension, just what I needed. Great job!

However, I do have something I would like to change.

If you compare the search input to let's say VS Code or Sublime it feels kind of sluggish with debounce of 200ms so I added the option to customize it, so everyone can tune it according to their own preferences.

I'm not sure if description is okay or position of the option.
If you want me to change anything let me know.
 