### PR TITLE
Tab order update delay of 0 ms is not respected

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -186,7 +186,10 @@ function setClosedTabsSize(val) {
  */
 function getTabOrderUpdateDelay() {
   var s = localStorage["tab_order_update_delay"];
-  return s ? parseInt(s, 10) || 1500 : 1500;
+  if (isNaN(s)) {
+    return 1500;
+  }
+  return parseInt(s, 10);
 }
 
 function setTabOrderUpdateDelay(val) {


### PR DESCRIPTION
Tab order update delay is parsed with `parseInt(s, 10) || 1500` which returns 1500 if `s` is 0, because JavaScript ¯\\\_(ツ)\_/¯

This fixes it.