### PR TITLE
Added option to keep closed tabs list after browser exit

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -255,6 +255,15 @@ function setJumpToLatestTabOnClose(val) {
   localStorage["jumpTo_latestTab_onClose"] = val;
 }
 
+function getClosedTabsListSave() {
+  var s = localStorage["closed_tabs_list_save"];
+  return s ? s === 'true' : true;
+}
+
+function setClosedTabsListSave(val) {
+  localStorage["closed_tabs_list_save"] = val;
+}
+
 /**
  * the actual last search string
  */
@@ -466,12 +475,30 @@ function resizeClosedTabs() {
   closedTabs.splice(getClosedTabsSize());
 }
 
+function removeClosedTab(url) {
+  var idx = indexOfTabByUrl(closedTabs, url);
+  if (idx >= 0) {
+    closedTabs.splice(idx, 1);
+    saveClosedTabs();
+  }
+}
+
 function addClosedTab(tab) {
   if (isWebUrl(tab.url)) {
     //    log("adding tab " + tab.id + " to closedTabs array " + tab.url);
     closedTabs.unshift({url: tab.url, title: tab.title, favIconUrl: tab.favIconUrl});
+    saveClosedTabs();
   }
   resizeClosedTabs();
+}
+
+function saveClosedTabs() {
+  if (getClosedTabsListSave()) {
+    // save closedTabs after a delay to avoid saving all tabs on browser exit
+    setTimeout(function () {
+      localStorage["closed_tabs"] = JSON.stringify(closedTabs);
+    }, 10000);
+  }
 }
 
 /**
@@ -826,6 +853,10 @@ function init() {
   chrome.bookmarks.onMoved.addListener(function() {setupBookmarks()});
 
   setupBookmarks();
+
+  if (getClosedTabsListSave()) {
+    closedTabs = JSON.parse(localStorage["closed_tabs"] || '[]');
+  }
 }
 
 init();

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -233,6 +233,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </td>
       </tr>
       <tr>
+        <td colspan="2" class="checkboxRow">
+          <label>
+            <input type="checkbox" id="closed_tabs_list_save" />
+            Closed tabs list persists after browser exit
+          </label>
+        </td>
+      </tr>
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -75,6 +75,7 @@ $(document).ready(function() {
   $("#jumpTo_latestTab_onClose").attr('checked', bg.getJumpToLatestTabOnClose());
   $("#tab_order_update_delay").val(bg.getTabOrderUpdateDelay());
   $("#debounce_delay").val(bg.getDebounceDelay());
+  $("#closed_tabs_list_save").attr('checked', bg.getClosedTabsListSave());
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
   var sk = bg.getShortcutKey();
@@ -120,6 +121,7 @@ $(document).ready(function() {
     bg.setJumpToLatestTabOnClose($("#jumpTo_latestTab_onClose").is(':checked'));
     bg.setTabOrderUpdateDelay($("#tab_order_update_delay").val());
     bg.setDebounceDelay($("#debounce_delay").val());
+    bg.setClosedTabsListSave($("#closed_tabs_list_save").is(':checked'));
     // bg.rebindShortcutKeys();
     bg.updateBadgeText();
 

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -598,6 +598,10 @@ function renderTabs(params, delay, currentTab) {
     let fOpenNewTab = function(e) {
       e.stopPropagation();
       openInNewTab(this.getAttribute('data-path'));
+
+      if (this.classList.contains('closed')) {
+        bg.removeClosedTab(this.getAttribute('data-path'));
+      }
     };
 
     $('.closed').on('click', fOpenNewTab);


### PR DESCRIPTION
New option allows to keep the list of closed tabs after the browser restarts.

![option](https://github.com/babyman/quick-tabs-chrome-extension/assets/20987209/56fbd546-5f13-449a-83b8-7fcc09d6229c)
