### PR TITLE
add middle click to close tab

### DIFF
--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -614,6 +614,13 @@ function renderTabs(params, delay, currentTab) {
       bg.switchTabsWithoutDelay(parseInt(this.id));
     });
 
+    $('.open').on('mousedown', function(e) {
+      if(e.button === 1) {
+        e.stopPropagation();
+        closeTabs([parseInt(this.id)]);
+      }
+    });
+
     $('.close').on('click', function(e) {
       e.stopPropagation();
       closeTabs([parseInt(this.id.substring(1))]);


### PR DESCRIPTION
to close a tab, we can now click the middle button of the mouse (wheel) on an item alongside clicking the `x` button on the right