### PR TITLE
Migration to manifest v3

### DIFF
--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -204,7 +204,7 @@ function initBadgeIcon() {
  */
 function updateBadgeText() {
   if (Config.get(SHOW_TAB_COUNT)) {
-    var val = tabs.filter(tab => Config.validTab(tab) && Config.includeTab(tab)).length;
+    var val = tabs.filter(tab => Utils.validTab(tab) && Utils.includeTab(tab)).length;
 
     chrome.action.setBadgeText({text: val + ""});
   } else {
@@ -281,7 +281,7 @@ function updateTabsOrder(tabArray) {
 }
 
 function recordTab(tab) {
-  if (Config.includeTab(tab)) {
+  if (Utils.includeTab(tab)) {
     log('recording tab', tab.id);
     tabs.push(tab);
   }
@@ -438,7 +438,7 @@ function init() {
 
   // attach an event handler to capture tabs as they are opened
   chrome.tabs.onCreated.addListener(function(tab) {
-    if (!Config.includeTab(tab)) {
+    if (!Utils.includeTab(tab)) {
       return;
     }
     //      log('created tab', tab, 'selected tab is ', t2);

--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -383,6 +383,21 @@ async function reloadConfig() {
 
 function init() {
 
+  // This block can be removed in the future, when all users have updated to the current version.
+  // We need to open a page to copy data from localStorage (not accesible from SW) to chrome.storage.local.
+  // We could use 'chrome.action.openPopup' or Offscreen API, but it's better to use 'chrome.tabs.create'
+  // for backward compability with previous Chrome versions and other Chromium browsers.
+  if (!Config.get(INSTALLED_AT)) {
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+      if (msg.firstRun) {
+        chrome.tabs.remove(sender.tab.id);
+        Config.init().then(init);
+      }
+    });
+    chrome.tabs.create({ url: "popup.html?firstRun=true", active: false });
+    return;
+  }
+
   debug = Config.get(DEBUG);
 
   // reset the extension state

--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -556,6 +556,11 @@ function init() {
   if (Config.get(CLOSED_TABS_LIST_SAVE)) {
     closedTabs = JSON.parse(Config.get(CLOSED_TABS) || '[]');
   }
+
+  // keep the service worker alive
+  const keepAlive = () => setInterval(chrome.runtime.getPlatformInfo, 25_000);
+  chrome.runtime.onStartup.addListener(keepAlive);
+  keepAlive();
 }
 
 if (self.Config) {

--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -600,10 +600,9 @@ async function init() {
     closedTabs = JSON.parse(Config.get(CLOSED_TABS) || '[]');
   }
 
-  // keep the service worker alive
-  const keepAlive = () => setInterval(chrome.runtime.getPlatformInfo, 25_000);
-  chrome.runtime.onStartup.addListener(keepAlive);
-  keepAlive();
+  // keep the service worker alive, perhaps not a beautifull solution,
+  // but that's better than a constantly restarting service worker
+  setInterval(chrome.runtime.getPlatformInfo, 25_000);
 }
 
 if (self.Config) {

--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -113,7 +113,7 @@ function isWebUrl(url) {
  */
 function log() {
   if (Config.get(DEBUG)) {
-    console.log.apply(console, Array.prototype.slice.call(arguments))
+    console.log((new Date).toISOString(), ...arguments);
   }
 }
 

--- a/quick-tabs/background.js
+++ b/quick-tabs/background.js
@@ -25,6 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+'use strict';
+
 /**
  * Utility Objects
  */
@@ -54,47 +56,6 @@ function DelayedFunction(f, timeout) {
     tabOrderUpdateFunction = null; // have to set variable null so that it's evaluated as false
   };
 }
-
-/**
- * Returns a function, that, as long as it continues to be invoked, will not
- * be triggered. The function will be called after it stops being called for
- * N milliseconds. If `immediate` is passed, trigger the function on the
- * leading edge, instead of the trailing.
- */
-function debounce(func, wait, immediate) {
-  var timeout;
-  return function() {
-    var context = this, args = arguments;
-    clearTimeout(timeout);
-    //Moving this line above timeout assignment
-    if (immediate && !timeout) {
-      func.apply(context, args);
-    }
-    timeout = setTimeout(function() {
-      timeout = null;
-      if (!immediate) {
-        func.apply(context, args);
-      }
-    }, wait);
-  };
-}
-
-
-function ShortcutKey(properties) {
-  this.ctrl = properties.ctrl || false;
-  this.shift = properties.shift || false;
-  this.alt = properties.alt || false;
-  this.meta = properties.meta || false;
-  this.key = properties.key || '';
-}
-
-ShortcutKey.prototype.pattern = function() {
-  return (this.alt ? "alt_" : "")
-      + (this.meta ? "meta_" : "")
-      + (this.ctrl ? "ctrl_" : "")
-      + (this.shift ? "shift_" : "")
-      + (this.key);
-};
 
 /**
  * arrays to hold the current order of the tabs, closed tabs and bookmarks
@@ -139,7 +100,7 @@ var debugBadgeColor = {color: [255, 0, 0, 255]};
  */
 var tabTimerBadgeColor = {color: [255, 106, 0, 255]};
 
-var debug = loadDebug();
+var debug = false;
 
 var re = /^https?:\/\/.*/;
 
@@ -151,14 +112,9 @@ function isWebUrl(url) {
  * Simple log wrapper to centralise logging for all of the code, called from popup.js as bg.log(....)
  */
 function log() {
-  if (debug) {
+  if (Config.get(DEBUG)) {
     console.log.apply(console, Array.prototype.slice.call(arguments))
   }
-}
-
-function loadDebug() {
-  var s = localStorage["debug_?"];
-  return s ? s === 'true' : false;
 }
 
 /**
@@ -168,17 +124,7 @@ function loadDebug() {
  */
 function setDebug(val) {
   debug = val;
-  localStorage["debug_?"] = val;
-}
-
-function getClosedTabsSize() {
-  var s = localStorage["closed_tabs_size"];
-  return s ? parseInt(s, 10) || 0 : 10;
-}
-
-function setClosedTabsSize(val) {
-  localStorage["closed_tabs_size"] = val;
-  resizeClosedTabs();
+  Config.set(DEBUG, val);
 }
 
 /**
@@ -187,292 +133,15 @@ function setClosedTabsSize(val) {
  * @returns {number} delay in ms a tab must be in focus before it is moved to the top of the open tabs list
  */
 function getTabOrderUpdateDelay() {
-  let s = localStorage["tab_order_update_delay"];
+  let s = Config.get(TAB_ORDER_UPDATE_DELAY);
   if(s === "0") {
     return 0;
   }
   return s ? parseInt(s, 10) || 1500 : 1500;
 }
 
-function setTabOrderUpdateDelay(val) {
-  localStorage["tab_order_update_delay"] = val;
-  resizeClosedTabs();
-}
-
-function pageupPagedownSkipSize() {
-  return localStorage["pageup_pagedown_skip_size"] || 5;
-}
-
-function setPageupPagedownSkipSize(val) {
-  localStorage["pageup_pagedown_skip_size"] = val;
-}
-
-function showDevTools() {
-  var s = localStorage["include_dev_tools"];
-  return s ? s === 'true' : false;
-}
-
-function setShowDevTools(val) {
-  localStorage["include_dev_tools"] = val;
-}
-
-function autoSearchBookmarks() {
-  var s = localStorage["auto_search_bookmarks"];
-  return s ? s === 'true' : true;
-}
-
-function setAutoSearchBookmarks(val) {
-  localStorage["auto_search_bookmarks"] = val;
-}
-
-function showUrls() {
-  var s = localStorage["show_urls"];
-  return s ? s === 'true' : true;
-}
-
-function setShowUrls(val) {
-  localStorage["show_urls"] = val;
-}
-
-/**
- * boolean option indicating if the last search string should be restored
- */
-function restoreLastSearchedStr() {
-  var s = localStorage["restore_last_searched_str"];
-  return s ? s === 'true' : true;
-}
-
-function setRestoreLastSearchedStr(val) {
-  localStorage["restore_last_searched_str"] = val;
-}
-
-function getJumpToLatestTabOnClose() {
-  var s = localStorage["jumpTo_latestTab_onClose"];
-  return s ? s === 'true' : false;
-}
-
-function setJumpToLatestTabOnClose(val) {
-  localStorage["jumpTo_latestTab_onClose"] = val;
-}
-
-function getClosedTabsListSave() {
-  var s = localStorage["closed_tabs_list_save"];
-  return s ? s === 'true' : true;
-}
-
-function setClosedTabsListSave(val) {
-  localStorage["closed_tabs_list_save"] = val;
-}
-
-/**
- * the actual last search string
- */
-function lastSearchedStr() {
-  return localStorage["last_searched_str"];
-}
-
-function setLastSearchedStr(val) {
-  localStorage["last_searched_str"] = val;
-}
-
-function searchType() {
-  var searchType = localStorage["search_type"];
-  var oldFuzzySetting = "fuseT1";
-  switch (localStorage["search_fuzzy"]) {
-    case "true":
-      oldFuzzySetting = "fuse";
-      break;
-    case "false":
-      oldFuzzySetting = "regex";
-      break;
-  }
-  return searchType ? searchType : oldFuzzySetting;
-}
-
-function setSearchType(val) {
-  localStorage["search_type"] = val;
-}
-
-function searchUrls() {
-  var s = localStorage["search_urls"];
-  return s ? s === 'true' : false;
-}
-
-function setSearchUrls(val) {
-  localStorage["search_urls"] = val;
-}
-
-function showTabCount() {
-  var s = localStorage["show_tab_count"];
-  return s ? s === 'true' : true;
-}
-
-function setShowTabCount(val) {
-  localStorage["show_tab_count"] = val;
-  updateBadgeText();
-}
-
-function showTooltips() {
-  var s = localStorage["show_tooltips"];
-  return s ? s === 'true' : true;
-}
-
-function setShowTooltips(val) {
-  localStorage["show_tooltips"] = val;
-}
-
-function showFavicons() {
-  var s = localStorage["show_favicons"];
-  return s ? s === 'true' : true;
-}
-
-function moveLeftOnSwitch() {
-  var s = localStorage["move_left_on_switch"];
-  return s ? s === 'true' : false;
-}
-
-function setMoveLeftOnSwitch(val) {
-  localStorage["move_left_on_switch"] = val;
-}
-
-function moveRightOnSwitch() {
-  // IMPORTANT: "move_on_switch" is a legacy name, do not change
-  var s = localStorage["move_on_switch"];
-  return s ? s === 'true' : false;
-}
-
-function setMoveRightOnSwitch(val) {
-  // IMPORTANT: "move_on_switch" is a legacy name, do not change
-  localStorage["move_on_switch"] = val;
-}
-
-/**
- * fix for #296 - Would it be possible to have an additional checkbox that enables the previous behaviour so that "Move tab to rightmost position on switch"
- * only applies if I have actually activated the extension, instead of applying all the time?
- */
-function moveOnPopupSwitchOnly() {
-  let s = localStorage["move_on_popup_switch_only"];
-  return s ? s === 'true' : true;
-}
-
-function setMoveOnPopupSwitchOnly(val) {
-  localStorage["move_on_popup_switch_only"] = val;
-}
-
-function setShowFavicons(val) {
-  localStorage["show_favicons"] = val;
-}
-
-function showPinnedTabs() {
-  var s = localStorage["show_pinned_tabs"];
-  return s ? s === 'true' : true;
-}
-
-function setShowPinnedTabs(val) {
-  localStorage["show_pinned_tabs"] = val;
-}
-
-function orderTabsInWindowOrder() {
-  var s = localStorage["order_tabs_in_window_order"];
-  return s ? s === 'true' : false;
-}
-
-function setOrderTabsInWindowOrder(val) {
-  localStorage["order_tabs_in_window_order"] = val;
-}
-
-function orderTabsByUrl() {
-  var s = localStorage["order_tabs_by_url"];
-  return s ? s === 'true' : false;
-}
-
-function setOrderTabsByUrl(val) {
-  localStorage["order_tabs_by_url"] = val;
-}
-
-function getSearchString() {
-  return localStorage["search_string"] || 'https://www.google.com/search?q=%s';
-}
-
-function setSearchString(val) {
-  localStorage["search_string"] = val;
-}
-
-function getDebounceDelay() {
-  return localStorage["debounce_delay"] || 200
-}
-
-function setDebounceDelay(val) {
-  localStorage["debounce_delay"] = val;
-}
-
-function getCustomCss() {
-  return localStorage["custom_css"] || '';
-}
-
-function setCustomCss(val) {
-  localStorage["custom_css"] = val;
-}
-
-function getHistoryFilter() {
-  return localStorage["history_filter"] || '';
-}
-
-function setHistoryFilter(val) {
-  localStorage["history_filter"] = val;
-}
-
-function getShortcutKey() {
-  return getKeyCombo("key_popup", "");
-}
-
-function clearOldShortcutKey() {
-  localStorage["key_popup"] = null
-}
-
-/**
- * make sure the tab is usable for search etc (see PR #314 and related issues #251, #310, #275, #313).
- */
-function validTab(tab) {
-  return tab && tab.title;
-}
-
-function includeTab(tab) {
-  return !(!showDevTools() && /chrome-devtools:\/\//.exec(tab.url)) && !(!showPinnedTabs() && tab.pinned);
-}
-
-function getKeyCombo(savedAs, def) {
-  if (localStorage[savedAs] && localStorage[savedAs].startsWith("{")) {
-    return new ShortcutKey(JSON.parse(localStorage[savedAs]));
-  } else {
-    return new ShortcutKey(def);
-  }
-}
-
-function setKeyCombo(saveAs, key) {
-  localStorage[saveAs] = JSON.stringify(key);
-}
-
-function getCloseTabKey() {
-  return getKeyCombo("close_tab_popup", {ctrl: true, key: "d"});
-}
-
-function setCloseTabKey(key) {
-  return setKeyCombo("close_tab_popup", key);
-}
-
-
-function getNewTabKey() {
-  return getKeyCombo("new_tab_popup", {ctrl: true, key: "return"});
-}
-
-function setNewTabKey(key) {
-  key.key = 'return'; // always use return to trigger this =)
-  return setKeyCombo("new_tab_popup", key);
-}
-
 function resizeClosedTabs() {
-  closedTabs.splice(getClosedTabsSize());
+  closedTabs.splice(Config.get(CLOSED_TABS_SIZE));
 }
 
 function removeClosedTab(url) {
@@ -493,10 +162,10 @@ function addClosedTab(tab) {
 }
 
 function saveClosedTabs() {
-  if (getClosedTabsListSave()) {
+  if (Config.get(CLOSED_TABS_LIST_SAVE)) {
     // save closedTabs after a delay to avoid saving all tabs on browser exit
     setTimeout(function () {
-      localStorage["closed_tabs"] = JSON.stringify(closedTabs);
+      Config.set(CLOSED_TABS, JSON.stringify(closedTabs));
     }, 10000);
   }
 }
@@ -526,7 +195,7 @@ function indexOfTabByUrl(tabArray, url) {
 
 function initBadgeIcon() {
   // set the badge colour
-  chrome.browserAction.setBadgeBackgroundColor(debug ? debugBadgeColor : badgeColor);
+  chrome.action.setBadgeBackgroundColor(debug ? debugBadgeColor : badgeColor);
   updateBadgeText();
 }
 
@@ -534,12 +203,12 @@ function initBadgeIcon() {
  * update the number of open tabs displayed on the extensions badge/icon
  */
 function updateBadgeText() {
-  if (showTabCount()) {
-    var val = tabs.filter(tab => validTab(tab) && includeTab(tab)).length;
+  if (Config.get(SHOW_TAB_COUNT)) {
+    var val = tabs.filter(tab => Config.validTab(tab) && Config.includeTab(tab)).length;
 
-    chrome.browserAction.setBadgeText({text: val + ""});
+    chrome.action.setBadgeText({text: val + ""});
   } else {
-    chrome.browserAction.setBadgeText({text: ""});
+    chrome.action.setBadgeText({text: ""});
   }
 }
 
@@ -556,7 +225,7 @@ function updateTabOrder(tabId) {
   }
 
   // change the badge color while the tab change timer is active
-  chrome.browserAction.setBadgeBackgroundColor(tabTimerBadgeColor);
+  chrome.action.setBadgeBackgroundColor(tabTimerBadgeColor);
 
   if (tabOrderUpdateFunction) {
     // clear current timer
@@ -574,12 +243,12 @@ function updateTabOrder(tabId) {
       activeTabsIndex = 0; // sync tabs[] pointer and actual current tab
 
       // move the tab if required
-      if (!moveOnPopupSwitchOnly()) {
+      if (!Config.get(MOVE_ON_POPUP_SWITCH_ONLY)) {
         moveTab(tab)
       }
     }
     // reset the badge color
-    chrome.browserAction.setBadgeBackgroundColor(debug ? debugBadgeColor : badgeColor);
+    chrome.action.setBadgeBackgroundColor(debug ? debugBadgeColor : badgeColor);
     tabOrderUpdateFunction.cancel(); // #note big bug. Function was never canceled and hence tabOrderUpdateFunction always true
   }, tabId === skipTabOrderUpdateTimer ? 0 : getTabOrderUpdateDelay());
 
@@ -595,10 +264,10 @@ function updateTabOrder(tabId) {
  */
 function moveTab(tab) {
   if(!tab.pinned) {
-    if (moveLeftOnSwitch()) {
+    if (Config.get(MOVE_LEFT_ON_SWITCH)) {
       log("moving tab to the left", tab.id);
       chrome.tabs.move(tab.id, {index: 0});
-    } else if (moveRightOnSwitch()) {
+    } else if (Config.get(MOVE_ON_SWITCH)) {
       log("moving tab to the right", tab.id);
       chrome.tabs.move(tab.id, {index: -1});
     }
@@ -612,7 +281,7 @@ function updateTabsOrder(tabArray) {
 }
 
 function recordTab(tab) {
-  if (includeTab(tab)) {
+  if (Config.includeTab(tab)) {
     log('recording tab', tab.id);
     tabs.push(tab);
   }
@@ -654,7 +323,7 @@ function switchTabs(tabid) {
       chrome.tabs.update(tabid, {active: true}, function(tab) {
         // // move the tab if required
         log("switched tabs", tabid, tab);
-        if (moveOnPopupSwitchOnly()) {
+        if (Config.get(MOVE_ON_POPUP_SWITCH_ONLY)) {
           moveTab(tab);
         }
       });
@@ -694,7 +363,27 @@ function setupBookmarks() {
   });
 }
 
+function getTabs() {
+  return tabs;
+}
+
+function getClosedTabs() {
+  return closedTabs;
+}
+
+function getBookmarks() {
+  return bookmarks;
+}
+
+async function reloadConfig() {
+  await Config.init();
+  updateBadgeText();
+  resizeClosedTabs();
+}
+
 function init() {
+
+  debug = Config.get(DEBUG);
 
   // reset the extension state
   tabs = [];
@@ -727,14 +416,14 @@ function init() {
   // attach an event handler to capture tabs as they are closed
   chrome.tabs.onRemoved.addListener(function(tabId) {
     recordTabsRemoved([tabId], null);
-    if (getJumpToLatestTabOnClose()) {
+    if (Config.get(JUMP_TO_LATEST_TAB_ON_CLOSE)) {
       switchTabs(tabs[activeTabsIndex].id); // jump to latest = tabs[0]
     }
   });
 
   // attach an event handler to capture tabs as they are opened
   chrome.tabs.onCreated.addListener(function(tab) {
-    if (!includeTab(tab)) {
+    if (!Config.includeTab(tab)) {
       return;
     }
     //      log('created tab', tab, 'selected tab is ', t2);
@@ -749,7 +438,7 @@ function init() {
     if (tab.active) {
       tabs.unshift(tab);
       updateTabOrder(tab.id); // change tab order only for tabs opened in foreground, hence were focused
-      if (!moveOnPopupSwitchOnly()) {
+      if (!Config.get(MOVE_ON_POPUP_SWITCH_ONLY)) {
         moveTab(tab);
       }
     } else {
@@ -854,13 +543,24 @@ function init() {
 
   setupBookmarks();
 
-  if (getClosedTabsListSave()) {
-    closedTabs = JSON.parse(localStorage["closed_tabs"] || '[]');
+  chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+    if (msg.call) {
+      if (typeof self[msg.call] === 'function') {
+        sendResponse(self[msg.call](msg.arg));
+      } else {
+        sendResponse({});
+      }
+    }
+  });
+
+  if (Config.get(CLOSED_TABS_LIST_SAVE)) {
+    closedTabs = JSON.parse(Config.get(CLOSED_TABS) || '[]');
   }
 }
 
-init();
-
+if (self.Config) {
+  init();
+}
 
 /**
  * Command action functions
@@ -884,4 +584,3 @@ function splitTabs(tabsToInclude) {
     });
   });
 }
-

--- a/quick-tabs/bg_wrapper.js
+++ b/quick-tabs/bg_wrapper.js
@@ -1,0 +1,2 @@
+importScripts("background.js", "config.js");
+Config.init().then(() => importScripts("background.js"));

--- a/quick-tabs/bg_wrapper.js
+++ b/quick-tabs/bg_wrapper.js
@@ -1,2 +1,2 @@
-importScripts("background.js", "config.js");
+importScripts("utils.js", "background.js", "config.js");
 Config.init().then(() => importScripts("background.js"));

--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -32,6 +32,7 @@ const SHOW_TAB_COUNT = 'show_tab_count';
 const SHOW_TOOLTIPS = 'show_tooltips';
 const SHOW_URLS = 'show_urls';
 const TAB_ORDER_UPDATE_DELAY = 'tab_order_update_delay';
+const TABS_ORDER = 'tabs_order';
 
 var Config = (function() {
   let data = {};

--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -51,8 +51,8 @@ var Config = (function() {
 
       // default values
       data[SEARCH_STRING] ??= 'https://www.google.com/search?q=%s';
-      data[CLOSE_TAB_POPUP] ??= '{"ctrl": true, "key": "d"}';
-      data[NEW_TAB_POPUP] ??= '{"ctrl": true, "key": "return"}';
+      data[CLOSE_TAB_POPUP] ??= { ctrl: true, key: "d" };
+      data[NEW_TAB_POPUP] ??= { ctrl: true, key: "return" };
       data[SEARCH_TYPE] ??= 'fuseT1';
       data[TAB_ORDER_UPDATE_DELAY] ??= 1500;
       data[PAGEUP_PAGEDOWN_SKIP_SIZE] ??= 5;
@@ -79,30 +79,23 @@ var Config = (function() {
     },
 
     getKeyCombo: function (savedAs) {
-      if (data[savedAs]?.startsWith("{")) {
-        return new ShortcutKey(JSON.parse(data[savedAs]));
-      } else {
-        return new ShortcutKey({});
+      let key = data[savedAs];
+      if (typeof key === 'string') {
+        try {
+          key = JSON.parse(key);
+        } catch(e) {
+          key = {};
+        }
       }
+      return new ShortcutKey(key || {});
     },
 
     setKeyCombo: function (saveAs, key) {
       if (saveAs === NEW_TAB_POPUP) {
         key.key = 'return'; // always use return to trigger this =)
       }
-      data[saveAs] = JSON.stringify(key);
+      this.set(saveAs, key);
     },
-
-    includeTab: function (tab) {
-      return !(!this.get(INCLUDE_DEV_TOOLS) && /chrome-devtools:\/\//.exec(tab.url)) && !(!this.get(SHOW_PINNED_TABS) && tab.pinned);
-    },
-
-    /**
-     * make sure the tab is usable for search etc (see PR #314 and related issues #251, #310, #275, #313).
-     */
-    validTab: function (tab) {
-      return tab && tab.title;
-    }
   };
 
 })();

--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const AUTO_SEARCH_BOOKMARKS = 'auto_search_bookmarks';
+const CLOSE_TAB_POPUP = 'close_tab_popup';
+const CLOSED_TABS_SIZE = 'closed_tabs_size';
+const CLOSED_TABS = 'closed_tabs';
+const CLOSED_TABS_LIST_SAVE = 'closed_tabs_list_save';
+const CUSTOM_CSS = 'custom_css';
+const DEBOUNCE_DELAY = 'debounce_delay';
+const DEBUG = 'debug';
+const HISTORY_FILTER = 'history_filter';
+const INCLUDE_DEV_TOOLS = 'include_dev_tools';
+const INSTALLED_AT = 'installed_at';
+const JUMP_TO_LATEST_TAB_ON_CLOSE = 'jumpTo_latestTab_onClose';
+const KEY_POPUP = 'key_popup';
+const LAST_SEARCHED_STR = 'last_searched_str';
+const MOVE_LEFT_ON_SWITCH = 'move_left_on_switch';
+/**
+ * fix for #296 - Would it be possible to have an additional checkbox that enables the previous behaviour so that "Move tab to rightmost position on switch"
+ * only applies if I have actually activated the extension, instead of applying all the time?
+ */
+const MOVE_ON_POPUP_SWITCH_ONLY = 'move_on_popup_switch_only';
+// IMPORTANT: "move_on_switch" is a legacy name, do not change
+const MOVE_ON_SWITCH = 'move_on_switch';
+const NEW_TAB_POPUP = 'new_tab_popup';
+const ORDER_TABS_BY_URL = 'order_tabs_by_url';
+const ORDER_TABS_IN_WINDOW_ORDER = 'order_tabs_in_window_order';
+const PAGEUP_PAGEDOWN_SKIP_SIZE = 'pageup_pagedown_skip_size';
+const RESTORE_LAST_SEARCHED_STR = 'restore_last_searched_str';
+const SEARCH_FUZZY = 'search_fuzzy';
+const SEARCH_STRING = 'search_string';
+const SEARCH_TYPE = 'search_type';
+const SEARCH_URLS = 'search_urls';
+const SHOW_FAVICONS = 'show_favicons';
+const SHOW_PINNED_TABS = 'show_pinned_tabs';
+const SHOW_TAB_COUNT = 'show_tab_count';
+const SHOW_TOOLTIPS = 'show_tooltips';
+const SHOW_URLS = 'show_urls';
+const TAB_ORDER_UPDATE_DELAY = 'tab_order_update_delay';
+
+var Config = (function() {
+  let data = {};
+
+  return {
+    init: async function () {
+      let opt = await chrome.storage.local.get(INSTALLED_AT);
+      if (!opt[INSTALLED_AT]) {
+        // transfer from localStorage to chrome.storage.local
+        chrome.storage.local.set({ [INSTALLED_AT]: Date.now() });
+        let storageCopy = Object.assign({}, window.localStorage || {});
+        Object.entries(storageCopy).forEach(([k, v]) => { storageCopy[k] = v === 'true' ? true : v === 'false' ? false : v });
+        await chrome.storage.local.set(storageCopy);
+      }
+
+      data = await chrome.storage.local.get(null);
+
+      // default values
+      data[SEARCH_STRING] ??= 'https://www.google.com/search?q=%s';
+      data[CLOSE_TAB_POPUP] ??= '{ctrl: true, key: "d"}';
+      data[NEW_TAB_POPUP] ??= '{ctrl: true, key: "return"}';
+      data[PAGEUP_PAGEDOWN_SKIP_SIZE] ??= 5;
+      data[CLOSED_TABS_SIZE] ??= 10;
+      data[CLOSED_TABS_LIST_SAVE] ??= true;
+      data[MOVE_ON_POPUP_SWITCH_ONLY] ??= true;
+      data[SHOW_FAVICONS] ??= true;
+      data[SHOW_TAB_COUNT] ??= true;
+      data[SHOW_TOOLTIPS] ??= true;
+      data[SHOW_URLS] ??= true;
+      data[SHOW_PINNED_TABS] ??= true;
+      data[AUTO_SEARCH_BOOKMARKS] ??= true;
+    },
+
+    get: function (key) {
+      return data[key];
+    },
+
+    set: async function (key, value) {
+      data[key] = value;
+      await chrome.storage.local.set({ [key]: value });
+    },
+
+    getKeyCombo: function (savedAs) {
+      if (data[savedAs]?.startsWith("{")) {
+        return new ShortcutKey(JSON.parse(data[savedAs]));
+      } else {
+        return new ShortcutKey({});
+      }
+    },
+
+    setKeyCombo: function (saveAs, key) {
+      if (saveAs === NEW_TAB_POPUP) {
+        key.key = 'return'; // always use return to trigger this =)
+      }
+      data[saveAs] = JSON.stringify(key);
+    },
+
+    includeTab: function (tab) {
+      return !(!this.get(INCLUDE_DEV_TOOLS) && /chrome-devtools:\/\//.exec(tab.url)) && !(!this.get(SHOW_PINNED_TABS) && tab.pinned);
+    },
+
+    /**
+     * make sure the tab is usable for search etc (see PR #314 and related issues #251, #310, #275, #313).
+     */
+    validTab: function (tab) {
+      return tab && tab.title;
+    }
+  };
+
+})();
+
+function ShortcutKey(properties) {
+  this.ctrl = properties.ctrl || false;
+  this.shift = properties.shift || false;
+  this.alt = properties.alt || false;
+  this.meta = properties.meta || false;
+  this.key = properties.key || '';
+}
+
+ShortcutKey.prototype.pattern = function() {
+  return (this.alt ? "alt_" : "")
+      + (this.meta ? "meta_" : "")
+      + (this.ctrl ? "ctrl_" : "")
+      + (this.shift ? "shift_" : "")
+      + (this.key);
+};

--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -44,20 +44,20 @@ var Config = (function() {
   return {
     init: async function () {
       let opt = await chrome.storage.local.get(INSTALLED_AT);
-      if (!opt[INSTALLED_AT]) {
+      if (!opt[INSTALLED_AT] && typeof window === 'object') {
         // transfer from localStorage to chrome.storage.local
-        chrome.storage.local.set({ [INSTALLED_AT]: Date.now() });
         let storageCopy = Object.assign({}, window.localStorage || {});
         Object.entries(storageCopy).forEach(([k, v]) => { storageCopy[k] = v === 'true' ? true : v === 'false' ? false : v });
         await chrome.storage.local.set(storageCopy);
+        chrome.storage.local.set({ [INSTALLED_AT]: Date.now() });
       }
 
       data = await chrome.storage.local.get(null);
 
       // default values
       data[SEARCH_STRING] ??= 'https://www.google.com/search?q=%s';
-      data[CLOSE_TAB_POPUP] ??= '{ctrl: true, key: "d"}';
-      data[NEW_TAB_POPUP] ??= '{ctrl: true, key: "return"}';
+      data[CLOSE_TAB_POPUP] ??= '{"ctrl": true, "key": "d"}';
+      data[NEW_TAB_POPUP] ??= '{"ctrl": true, "key": "return"}';
       data[PAGEUP_PAGEDOWN_SKIP_SIZE] ??= 5;
       data[CLOSED_TABS_SIZE] ??= 10;
       data[CLOSED_TABS_LIST_SAVE] ??= true;

--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -15,13 +15,8 @@ const JUMP_TO_LATEST_TAB_ON_CLOSE = 'jumpTo_latestTab_onClose';
 const KEY_POPUP = 'key_popup';
 const LAST_SEARCHED_STR = 'last_searched_str';
 const MOVE_LEFT_ON_SWITCH = 'move_left_on_switch';
-/**
- * fix for #296 - Would it be possible to have an additional checkbox that enables the previous behaviour so that "Move tab to rightmost position on switch"
- * only applies if I have actually activated the extension, instead of applying all the time?
- */
-const MOVE_ON_POPUP_SWITCH_ONLY = 'move_on_popup_switch_only';
-// IMPORTANT: "move_on_switch" is a legacy name, do not change
-const MOVE_ON_SWITCH = 'move_on_switch';
+const MOVE_ON_POPUP_SWITCH_ONLY = 'move_on_popup_switch_only'; // fix for #296
+const MOVE_ON_SWITCH = 'move_on_switch'; // IMPORTANT: "move_on_switch" is a legacy name, do not change
 const NEW_TAB_POPUP = 'new_tab_popup';
 const ORDER_TABS_BY_URL = 'order_tabs_by_url';
 const ORDER_TABS_IN_WINDOW_ORDER = 'order_tabs_in_window_order';
@@ -58,16 +53,20 @@ var Config = (function() {
       data[SEARCH_STRING] ??= 'https://www.google.com/search?q=%s';
       data[CLOSE_TAB_POPUP] ??= '{"ctrl": true, "key": "d"}';
       data[NEW_TAB_POPUP] ??= '{"ctrl": true, "key": "return"}';
+      data[SEARCH_TYPE] ??= 'fuseT1';
+      data[TAB_ORDER_UPDATE_DELAY] ??= 1500;
       data[PAGEUP_PAGEDOWN_SKIP_SIZE] ??= 5;
       data[CLOSED_TABS_SIZE] ??= 10;
-      data[CLOSED_TABS_LIST_SAVE] ??= true;
+      data[DEBOUNCE_DELAY] ??= 200;
+      data[RESTORE_LAST_SEARCHED_STR] ??= true;
       data[MOVE_ON_POPUP_SWITCH_ONLY] ??= true;
-      data[SHOW_FAVICONS] ??= true;
+      data[AUTO_SEARCH_BOOKMARKS] ??= true;
+      data[CLOSED_TABS_LIST_SAVE] ??= true;
+      data[SHOW_PINNED_TABS] ??= true;
       data[SHOW_TAB_COUNT] ??= true;
+      data[SHOW_FAVICONS] ??= true;
       data[SHOW_TOOLTIPS] ??= true;
       data[SHOW_URLS] ??= true;
-      data[SHOW_PINNED_TABS] ??= true;
-      data[AUTO_SEARCH_BOOKMARKS] ??= true;
     },
 
     get: function (key) {

--- a/quick-tabs/manifest.json
+++ b/quick-tabs/manifest.json
@@ -23,8 +23,8 @@
   "commands": {
     "_execute_action": {
        "suggested_key": {
-         "default": "Ctrl+E",
-         "mac": "Command+E",
+         "default": "Ctrl+Q",
+         "mac": "Command+Q",
          "linux": "Ctrl+Q"
        }
     },

--- a/quick-tabs/manifest.json
+++ b/quick-tabs/manifest.json
@@ -14,7 +14,7 @@
     "48": "assets/icon-48.png"
   },
   "manifest_version": 3,
-  "name": "Quick Tabs MV3",
+  "name": "Quick Tabs",
   "options_page": "options.html",
   "permissions": [ "tabs", "bookmarks", "history", "storage" ],
 

--- a/quick-tabs/manifest.json
+++ b/quick-tabs/manifest.json
@@ -1,8 +1,8 @@
 {
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "bg_wrapper.js"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "assets/icon-32.png",
     "default_title": "Quick Tabs",
     "default_popup": "popup.html?popup=true"
@@ -13,18 +13,15 @@
     "32": "assets/icon-32.png",
     "48": "assets/icon-48.png"
   },
-  "minimum_chrome_version": "25",
-  "manifest_version": 2,
-  "offline_enabled": true,
-  "name": "Quick Tabs",
+  "manifest_version": 3,
+  "name": "Quick Tabs MV3",
   "options_page": "options.html",
-  "permissions": [ "tabs", "bookmarks", "history" ],
-  "update_url": "http://clients2.google.com/service/update2/crx",
+  "permissions": [ "tabs", "bookmarks", "history", "storage" ],
 
   "version": "2021.6.29",
 
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
        "suggested_key": {
          "default": "Ctrl+E",
          "mac": "Command+E",

--- a/quick-tabs/options.html
+++ b/quick-tabs/options.html
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <link rel="stylesheet" href="assets/styles.css" type="text/css" media="all"/>
   <link rel="stylesheet" href="assets/styles-options.css" type="text/css" media="all"/>
   <script type="text/javascript" src="js/jquery-3.5.1.min.js"></script>
+  <script type="text/javascript" src="config.js"></script>
   <script type="text/javascript" src="options.js"></script>
   <title>Quick Tabs Options</title>
 </head>
@@ -68,7 +69,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='show_tab_count'/>
+            <input type="checkbox" id="show_tab_count"/>
             Show badge tab count
           </label>
         </td>
@@ -76,7 +77,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='show_urls'/>
+            <input type="checkbox" id="show_urls"/>
             Show URLs
           </label>
         </td>
@@ -84,7 +85,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='show_tooltips'/>
+            <input type="checkbox" id="show_tooltips"/>
             Show page title as a tooltip
           </label>
         </td>
@@ -92,7 +93,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='show_favicons'/>
+            <input type="checkbox" id="show_favicons"/>
             Show page favicons
           </label>
         </td>
@@ -100,7 +101,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='tabs_in_window_order'/>
+            <input type="checkbox" id="tabs_in_window_order"/>
             Order tabs in window order
           </label>
         </td>
@@ -108,7 +109,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='tabs_by_url'/>
+            <input type="checkbox" id="tabs_by_url"/>
             Order tabs by URL
           </label>
         </td>
@@ -119,27 +120,27 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='radio' name='search_type' value="fuzzy"/>
+            <input type="radio" name="search_type" value="fuzzy"/>
             Perform <a href="https://github.com/mattyork/fuzzy" target="_blank">Fuzzy Search</a>
-          </label>
-        </td>
-      </tr>
-      <tr>
-    <td colspan="2" class="checkboxRow">
-          <label>
-            <input type='radio' name='search_type' value="fuseT1"/>
-            Perform <a href="http://fusejs.io/" target="_blank">Fuse Search</a> purely fuzzy
-          </label>
-       <label>
-            <input type='radio' name='search_type' value="fuseT2"/>
-      word-based
           </label>
         </td>
       </tr>
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='radio' name='search_type' value="regex"/>
+            <input type="radio" name="search_type" value="fuseT1"/>
+            Perform <a href="http://fusejs.io/" target="_blank">Fuse Search</a> purely fuzzy
+          </label>
+          <label>
+            <input type="radio" name="search_type" value="fuseT2"/>
+            word-based
+          </label>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2" class="checkboxRow">
+          <label>
+            <input type="radio" name="search_type" value="regex"/>
             Perform RegEx Search (<a href="http://en.wikipedia.org/wiki/Regular_expression" target="_blank">RegExp</a> pattern match search)
           </label>
         </td>
@@ -147,7 +148,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='radio' name='search_type' value="substring"/>
+            <input type="radio" name="search_type" value="substring"/>
             Perform Substring Search (exact string matching search)
           </label>
         </td>
@@ -165,7 +166,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='restore_last_searched_str'/>
+            <input type="checkbox" id="restore_last_searched_str"/>
             Keep last searched string in search box
           </label>
         </td>
@@ -173,7 +174,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='search_urls'/>
+            <input type="checkbox" id="search_urls"/>
             Always search URLs (even when not shown)
           </label>
         </td>
@@ -181,7 +182,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='auto_search_bookmarks'/>
+            <input type="checkbox" id="auto_search_bookmarks"/>
             Automatically include bookmarks in search (adding a space will always search bookmarks)
           </label>
         </td>
@@ -192,7 +193,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='move_left_on_switch'/>
+            <input type="checkbox" id="move_left_on_switch"/>
             Move tab to leftmost position on switch
           </label>
         </td>
@@ -200,7 +201,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='move_right_on_switch'/>
+            <input type="checkbox" id="move_right_on_switch"/>
             Move tab to rightmost position on switch
           </label>
         </td>
@@ -208,7 +209,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='move_on_popup_switch_only'/>
+            <input type="checkbox" id="move_on_popup_switch_only"/>
             Only move tabs when switched via the extension popup
           </label>
         </td>
@@ -219,7 +220,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='show_pinned_tabs'/>
+            <input type="checkbox" id="show_pinned_tabs"/>
             Include pinned tabs
           </label>
         </td>
@@ -227,7 +228,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <tr>
         <td colspan="2" class="checkboxRow">
           <label>
-            <input type='checkbox' id='jumpTo_latestTab_onClose'/>
+            <input type="checkbox" id="jumpTo_latestTab_onClose"/>
             Jump to previous tab on close of any tab (Tip: use to close tabs in reverse order, aka. undo your mess)
           </label>
         </td>
@@ -240,6 +241,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           </label>
         </td>
       </tr>
+      <tr>
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>
@@ -340,7 +342,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
           </label>
         </td>
         <td>
-          <input type='checkbox' id='show_dev_tools'/> (will take full effect on reload)
+          <input type="checkbox" id="show_dev_tools"/> (will take full effect on reload)
         </td>
       </tr>
     </table>

--- a/quick-tabs/options.js
+++ b/quick-tabs/options.js
@@ -24,6 +24,9 @@
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+"use strict";
+
 function displayKey(prefix, key) {
   $('#' + prefix + '_key').val(key.key);
   $('#' + prefix + '_ctrl').attr('checked', key.ctrl);
@@ -41,44 +44,43 @@ function assignKeyProperties(prefix, key) {
   return key;
 }
 
-var bg = chrome.extension.getBackgroundPage();
-
-$(document).ready(function() {
+$(document).ready(async function() {
+  await Config.init();
 
   // load the saved options
-  var closeTabKey = bg.getCloseTabKey();
-  var newTabKey = bg.getNewTabKey();
+  var closeTabKey = Config.getKeyCombo(CLOSE_TAB_POPUP);
+  var newTabKey = Config.getKeyCombo(NEW_TAB_POPUP);
 
   displayKey("close", closeTabKey);
   displayKey("new_tab", newTabKey);
 
-  $("#closed_tabs_size").val(bg.getClosedTabsSize());
-  $("#search_string").val(bg.getSearchString());
-  $("#history_filter").val(bg.getHistoryFilter());
-  $("#custom_css").val(bg.getCustomCss());
-  $("#auto_search_bookmarks").attr('checked', bg.autoSearchBookmarks());
-  $("#show_dev_tools").attr('checked', bg.showDevTools());
-  $("#show_urls").attr('checked', bg.showUrls());
-  $('input:radio[name="search_type"]').val([bg.searchType()]);
-  $("#search_urls").attr('checked', bg.searchUrls());
-  $("#show_tab_count").attr('checked', bg.showTabCount());
-  $("#show_tooltips").attr('checked', bg.showTooltips());
-  $("#show_favicons").attr('checked', bg.showFavicons());
-  $("#show_pinned_tabs").attr('checked', bg.showPinnedTabs());
-  $("#tabs_in_window_order").attr('checked', bg.orderTabsInWindowOrder());
-  $("#tabs_by_url").attr('checked', bg.orderTabsByUrl());
-  $("#pageup_pagedown_skip_size").val(bg.pageupPagedownSkipSize());
-  $("#move_left_on_switch").attr('checked', bg.moveLeftOnSwitch());
-  $("#move_right_on_switch").attr('checked', bg.moveRightOnSwitch());
-  $("#move_on_popup_switch_only").attr('checked', bg.moveOnPopupSwitchOnly());
-  $("#restore_last_searched_str").attr('checked', bg.restoreLastSearchedStr());
-  $("#jumpTo_latestTab_onClose").attr('checked', bg.getJumpToLatestTabOnClose());
-  $("#tab_order_update_delay").val(bg.getTabOrderUpdateDelay());
-  $("#debounce_delay").val(bg.getDebounceDelay());
-  $("#closed_tabs_list_save").attr('checked', bg.getClosedTabsListSave());
+  $('#closed_tabs_size').val(Config.get(CLOSED_TABS_SIZE));
+  $('#search_string').val(Config.get(SEARCH_STRING));
+  $('#history_filter').val(Config.get(HISTORY_FILTER));
+  $('#custom_css').val(Config.get(CUSTOM_CSS));
+  $('#auto_search_bookmarks').attr('checked', Config.get(AUTO_SEARCH_BOOKMARKS));
+  $('#show_dev_tools').attr('checked', Config.get(INCLUDE_DEV_TOOLS));
+  $('#show_urls').attr('checked', Config.get(SHOW_URLS));
+  $('input:radio[name="search_type"]').val([Config.get(SEARCH_TYPE)]);
+  $('#search_urls').attr('checked', Config.get(SEARCH_URLS));
+  $('#show_tab_count').attr('checked', Config.get(SHOW_TAB_COUNT));
+  $('#show_tooltips').attr('checked', Config.get(SHOW_TOOLTIPS));
+  $('#show_favicons').attr('checked', Config.get(SHOW_FAVICONS));
+  $('#show_pinned_tabs').attr('checked', Config.get(SHOW_PINNED_TABS));
+  $('#tabs_in_window_order').attr('checked', Config.get(ORDER_TABS_IN_WINDOW_ORDER));
+  $('#tabs_by_url').attr('checked', Config.get(ORDER_TABS_BY_URL));
+  $('#pageup_pagedown_skip_size').val(Config.get(PAGEUP_PAGEDOWN_SKIP_SIZE));
+  $('#move_left_on_switch').attr('checked', Config.get(MOVE_LEFT_ON_SWITCH));
+  $('#move_right_on_switch').attr('checked', Config.get(MOVE_ON_SWITCH));
+  $('#move_on_popup_switch_only').attr('checked', Config.get(MOVE_ON_POPUP_SWITCH_ONLY));
+  $('#restore_last_searched_str').attr('checked', Config.get(RESTORE_LAST_SEARCHED_STR));
+  $('#jumpTo_latestTab_onClose').attr('checked', Config.get(JUMP_TO_LATEST_TAB_ON_CLOSE));
+  $('#tab_order_update_delay').val(Config.get(TAB_ORDER_UPDATE_DELAY));
+  $('#debounce_delay').val(Config.get(DEBOUNCE_DELAY));
+  $('#closed_tabs_list_save').attr('checked', Config.get(CLOSED_TABS_LIST_SAVE));
 
   // if a shortcut key is defined alert the user that the shortcut key configuration has changed
-  var sk = bg.getShortcutKey();
+  var sk = Config.getKeyCombo(KEY_POPUP);
   if(sk.pattern() !== "") {
     $(".shortcutAlert > p").text("WARNING: the popup window shortcut key is now managed by Chrome, your old setting was " +
         sk.pattern() + ", see below.");
@@ -88,42 +90,41 @@ $(document).ready(function() {
         .animate({opacity: 1.0}, 3000);
 
     $("#shortcut_done").click(function () {
-      bg.clearOldShortcutKey();
+      Config.set(KEY_POPUP, null);
       $(".shortcutAlert").slideUp();
     });
   }
 
   // Update status to let user know options were saved.
   $("#save_btn").click(function() {
-    bg.setCloseTabKey(assignKeyProperties("close", closeTabKey));
-    bg.setNewTabKey(assignKeyProperties("new_tab", newTabKey));
+    Config.setKeyCombo(CLOSE_TAB_POPUP, assignKeyProperties("close", closeTabKey));
+    Config.setKeyCombo(NEW_TAB_POPUP, assignKeyProperties("new_tab", newTabKey));
 
-    bg.setClosedTabsSize($("#closed_tabs_size").val());
-    bg.setSearchString($("#search_string").val());
-    bg.setHistoryFilter($("#history_filter").val());
-    bg.setCustomCss($("#custom_css").val());
-    bg.setShowUrls($("#show_urls").is(':checked'));
-    bg.setSearchType($('input:radio[name="search_type"]:checked').val());
-    bg.setSearchUrls($("#search_urls").is(':checked'));
-    bg.setShowTabCount($("#show_tab_count").is(':checked'));
-    bg.setShowTooltips($("#show_tooltips").is(':checked'));
-    bg.setShowFavicons($("#show_favicons").is(':checked'));
-    bg.setShowPinnedTabs($("#show_pinned_tabs").is(':checked'));
-    bg.setOrderTabsInWindowOrder($("#tabs_in_window_order").is(':checked'));
-    bg.setOrderTabsByUrl($("#tabs_by_url").is(':checked'));
-    bg.setAutoSearchBookmarks($("#auto_search_bookmarks").is(':checked'));
-    bg.setShowDevTools($("#show_dev_tools").is(':checked'));
-    bg.setPageupPagedownSkipSize($("#pageup_pagedown_skip_size").val());
-    bg.setMoveLeftOnSwitch($("#move_left_on_switch").is(':checked'));
-    bg.setMoveRightOnSwitch($("#move_right_on_switch").is(':checked'));
-    bg.setMoveOnPopupSwitchOnly($("#move_on_popup_switch_only").is(':checked'));
-    bg.setRestoreLastSearchedStr($("#restore_last_searched_str").is(':checked'));
-    bg.setJumpToLatestTabOnClose($("#jumpTo_latestTab_onClose").is(':checked'));
-    bg.setTabOrderUpdateDelay($("#tab_order_update_delay").val());
-    bg.setDebounceDelay($("#debounce_delay").val());
-    bg.setClosedTabsListSave($("#closed_tabs_list_save").is(':checked'));
-    // bg.rebindShortcutKeys();
-    bg.updateBadgeText();
+    Config.set(CLOSED_TABS_SIZE, $('#closed_tabs_size').val());
+    Config.set(SEARCH_STRING, $('#search_string').val());
+    Config.set(HISTORY_FILTER, $('#history_filter').val());
+    Config.set(CUSTOM_CSS, $('#custom_css').val());
+    Config.set(SHOW_URLS, $('#show_urls').is(':checked'));
+    Config.set(SEARCH_TYPE, $('input:radio[name="search_type"]:checked').val());
+    Config.set(SEARCH_URLS, $('#search_urls').is(':checked'));
+    Config.set(SHOW_TAB_COUNT, $('#show_tab_count').is(':checked'));
+    Config.set(SHOW_TOOLTIPS, $('#show_tooltips').is(':checked'));
+    Config.set(SHOW_FAVICONS, $('#show_favicons').is(':checked'));
+    Config.set(SHOW_PINNED_TABS, $('#show_pinned_tabs').is(':checked'));
+    Config.set(ORDER_TABS_IN_WINDOW_ORDER, $('#tabs_in_window_order').is(':checked'));
+    Config.set(ORDER_TABS_BY_URL, $('#tabs_by_url').is(':checked'));
+    Config.set(AUTO_SEARCH_BOOKMARKS, $('#auto_search_bookmarks').is(':checked'));
+    Config.set(INCLUDE_DEV_TOOLS, $('#show_dev_tools').is(':checked'));
+    Config.set(PAGEUP_PAGEDOWN_SKIP_SIZE, $('#pageup_pagedown_skip_size').val());
+    Config.set(MOVE_LEFT_ON_SWITCH, $('#move_left_on_switch').is(':checked'));
+    Config.set(MOVE_ON_SWITCH, $('#move_right_on_switch').is(':checked'));
+    Config.set(MOVE_ON_POPUP_SWITCH_ONLY, $('#move_on_popup_switch_only').is(':checked'));
+    Config.set(RESTORE_LAST_SEARCHED_STR, $('#restore_last_searched_str').is(':checked'));
+    Config.set(JUMP_TO_LATEST_TAB_ON_CLOSE, $('#jumpTo_latestTab_onClose').is(':checked'));
+    Config.set(TAB_ORDER_UPDATE_DELAY, $('#tab_order_update_delay').val());
+    Config.set(DEBOUNCE_DELAY, $('#debounce_delay').val());
+    Config.set(CLOSED_TABS_LIST_SAVE, $('#closed_tabs_list_save').is(':checked'));
+    chrome.runtime.sendMessage({ call: 'reloadConfig' });
 
     // Update status to let user know options were saved.
     $(".alert").text("Options saved.")

--- a/quick-tabs/popup.html
+++ b/quick-tabs/popup.html
@@ -148,6 +148,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <script type="text/javascript" src="js/fuse.min.js"></script>
 <script type="text/javascript" src="js/fuzzy.js"></script>
 <script type="text/javascript" src="js/mustache.min.js"></script>
+<script type="text/javascript" src="utils.js"></script>
 <script type="text/javascript" src="config.js"></script>
 <script type="text/javascript" src="popup.js"></script>
 </body>

--- a/quick-tabs/popup.html
+++ b/quick-tabs/popup.html
@@ -148,6 +148,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <script type="text/javascript" src="js/fuse.min.js"></script>
 <script type="text/javascript" src="js/fuzzy.js"></script>
 <script type="text/javascript" src="js/mustache.min.js"></script>
+<script type="text/javascript" src="config.js"></script>
 <script type="text/javascript" src="popup.js"></script>
 </body>
 </html>

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -30,10 +30,14 @@
 (async function() {
 
 async function bg(name, arg) {
-  return await chrome.runtime.sendMessage({call: name, arg});
+  return await chrome.runtime.sendMessage({ call: name, arg });
 }
 
 await Config.init();
+
+if (getUrlParameter('firstRun') === 'true') {
+  await chrome.runtime.sendMessage({ firstRun: true });
+}
 
 let bgTabs = await bg('getTabs') || [];
 let bgClosedTabs = await bg('getClosedTabs') || [];

--- a/quick-tabs/popup.js
+++ b/quick-tabs/popup.js
@@ -274,7 +274,7 @@ function compareTabArrays(recordedTabsList, queryTabList) {
   }
 
   for (var extraTab in queriedTabsMap) {
-    if (queriedTabsMap.hasOwnProperty(extraTab) && Config.includeTab(queriedTabsMap[extraTab])) {
+    if (queriedTabsMap.hasOwnProperty(extraTab) && Utils.includeTab(queriedTabsMap[extraTab])) {
       log('  adding missing tab', queriedTabsMap[extraTab]);
       tabsToRender.push(queriedTabsMap[extraTab]);
     }
@@ -425,33 +425,9 @@ $(document).ready(async function() {
 });
 
 /**
- * Returns a function, that, as long as it continues to be invoked, will not
- * be triggered. The function will be called after it stops being called for
- * N milliseconds. If `immediate` is passed, trigger the function on the
- * leading edge, instead of the trailing.
- */
-function debounce(func, wait, immediate) {
-  var timeout;
-  return function() {
-    var context = this, args = arguments;
-    clearTimeout(timeout);
-    //Moving this line above timeout assignment
-    if (immediate && !timeout) {
-      func.apply(context, args);
-    }
-    timeout = setTimeout(function() {
-      timeout = null;
-      if (!immediate) {
-        func.apply(context, args);
-      }
-    }, wait);
-  };
-}
-
-/**
  * curry up a debounced version of performQuery()
  */
-const debouncedSearch = debounce(performQuery, debounceDelay);
+const debouncedSearch = Utils.debounce(performQuery, debounceDelay);
 
 /**
  * open a new tab with `searchString`, if it looks like a valid URL open that
@@ -557,7 +533,7 @@ function renderTabs(params, delay, currentTab) {
     if (currentTab && obj.id === currentTab.id) {
       log(obj.id, currentTab.id, obj.id !== currentTab.id, obj, currentTab);
     }
-    if (Config.includeTab(obj) && (!currentTab || obj.id !== currentTab.id)) {
+    if (Utils.includeTab(obj) && (!currentTab || obj.id !== currentTab.id)) {
       obj.templateTabImage = tabImage(obj);
       obj.templateTitle = encodeHTMLSource(obj.title);
       obj.templateTooltip = stripTitle(obj.title);
@@ -861,10 +837,10 @@ AbstractSearch.prototype.executeSearch = function(query, searchBookmark, searchH
 
   if (query.trim().length === 0) {
     // no need to search if the string is empty
-    filteredTabs = bgTabs.filter(Config.validTab);
+    filteredTabs = bgTabs.filter(Utils.validTab);
     filteredClosed = bgClosedTabs;
   } else if (query === audibleQuery) {
-    filteredTabs = bgTabs.filter(tab => Config.validTab(tab) && filterAudible(tab))
+    filteredTabs = bgTabs.filter(tab => Utils.validTab(tab) && filterAudible(tab))
   } else if (searchHistory || startsOrEndsWith(query, searchHistoryStr)) {
     // i hate to break out of a function part way though but...
     this.searchHistory(query, 0);
@@ -872,7 +848,7 @@ AbstractSearch.prototype.executeSearch = function(query, searchBookmark, searchH
   } else if (searchBookmark || startsOrEndsWith(query, searchBookmarkStr)) {
     filteredBookmarks = this.searchTabArray(query, bgBookmarks);
   } else {
-    filteredTabs = this.searchTabArray(query, bgTabs.filter(Config.validTab));
+    filteredTabs = this.searchTabArray(query, bgTabs.filter(Utils.validTab));
     filteredClosed = this.searchTabArray(query, bgClosedTabs);
     var resultCount = filteredTabs.length + filteredClosed.length;
     if (startsOrEndsWith(query, searchTabsBookmarksStr) || resultCount < MIN_TAB_ONLY_RESULTS) {

--- a/quick-tabs/utils.js
+++ b/quick-tabs/utils.js
@@ -1,0 +1,36 @@
+var Utils = {
+  includeTab: function (tab) {
+    return !(!Config.get(INCLUDE_DEV_TOOLS) && /chrome-devtools:\/\//.exec(tab.url)) && !(!Config.get(SHOW_PINNED_TABS) && tab.pinned);
+  },
+
+  /**
+   * make sure the tab is usable for search etc (see PR #314 and related issues #251, #310, #275, #313).
+   */
+  validTab: function (tab) {
+    return tab && tab.title;
+  },
+
+  /**
+   * Returns a function, that, as long as it continues to be invoked, will not
+   * be triggered. The function will be called after it stops being called for
+   * N milliseconds. If `immediate` is passed, trigger the function on the
+   * leading edge, instead of the trailing.
+   */
+  debounce: function (func, wait, immediate) {
+    var timeout;
+    return function() {
+      var context = this, args = arguments;
+      clearTimeout(timeout);
+      //Moving this line above timeout assignment
+      if (immediate && !timeout) {
+        func.apply(context, args);
+      }
+      timeout = setTimeout(function() {
+        timeout = null;
+        if (!immediate) {
+          func.apply(context, args);
+        }
+      }, wait);
+    };
+  },
+}


### PR DESCRIPTION
- Background page replaced with service worker
- `localStorage` migrated to `storage.local`
- Tested upgrading from the previous version with [Extension Update Testing Tool
](https://github.com/GoogleChromeLabs/extension-update-testing-tool)
- Tabs order is now persist between browser restarts, that's needed because a service worker could be restarted at any moment

Issues: #375 #380 