### PR TITLE
Bug fix: history entries are not available until options are saved

### DIFF
--- a/quick-tabs/config.js
+++ b/quick-tabs/config.js
@@ -55,6 +55,7 @@ var Config = (function() {
       data[CLOSE_TAB_POPUP] ??= { ctrl: true, key: "d" };
       data[NEW_TAB_POPUP] ??= { ctrl: true, key: "return" };
       data[SEARCH_TYPE] ??= 'fuseT1';
+      data[HISTORY_FILTER] ??= '';
       data[TAB_ORDER_UPDATE_DELAY] ??= 1500;
       data[PAGEUP_PAGEDOWN_SKIP_SIZE] ??= 5;
       data[CLOSED_TABS_SIZE] ??= 10;


### PR DESCRIPTION
In the MV3 migration changes I missed a default value for HISTORY_FILTER. That causes an error when the popup tries to get history entries. That happens after a clean install and until options are saved.