### PR TITLE
Fix Chrome Web Store link redirect issue in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Quick Tabs is a tab management browser extension for the Google Chrome web brows
 
 Quick Tabs allows you to move quickly between recently used tabs without requiring the use of your mouse, locate and switch to tabs as you need them with minimal keystrokes even when you have large numbers of open tabs.
 
-Visit the [Quick Tabs](https://chrome.google.com/extensions/detail/jnjfeinjfmenlddahdjdmgpbokiacbbb) google extensions page to install and try it out ...
+Visit the [Quick Tabs](https://chromewebstore.google.com/detail/quick-tabs/jnjfeinjfmenlddahdjdmgpbokiacbbb) google extensions page to install and try it out ...
 
 # FEATURES
 


### PR DESCRIPTION
## Problem
The Chrome Web Store link in the README currently uses the old chrome.google.com/webstore domain, which redirects to the store's homepage instead of the extension page. Users who click the link have to manually search for the extension.

## Solution  
Updates the link to use the new chromewebstore.google.com domain that Google introduced in January 2024.

## Impact
Users can now directly install the extension with one click instead of having to search for it.